### PR TITLE
remove dedupes

### DIFF
--- a/entities.py
+++ b/entities.py
@@ -1,39 +1,56 @@
-from anduril import Media, MediaItem, Entity, Provenance, Provenance
+from anduril import Media, MediaItem, Entity, Provenance
 from datetime import datetime, timezone
 import logging
+import os
 
-async def override_entity(operation, object_path, entity_id, client):
-    try:
-        latest_timestamp = datetime.now(timezone.utc)
-        
-        provenance = Provenance(
-            integration_name="your_integration_name",
-            data_type="test_data",
-            source_update_time=latest_timestamp
+INTEGRATION_NAME = os.getenv("INTEGRATION_NAME", "sample-app-thumbnail")
+DATA_TYPE = os.getenv("DATA_TYPE", "test_data")
+
+logger = logging.getLogger(__name__)
+
+
+async def override_entity(operation: str, object_path: str, entity_id: str, client) -> None:
+    """Override an entity's media component to link or unlink a thumbnail.
+
+    Args:
+        operation: Either "upload" (link image) or "delete" (clear media).
+        object_path: The object path returned by the Objects API.
+        entity_id: The target entity's unique ID.
+        client: An authenticated Lattice client instance.
+
+    Raises:
+        ValueError: If *operation* is not "upload" or "delete".
+    """
+    if operation == "upload":
+        media = Media(
+            media=[
+                MediaItem(
+                    relative_path=object_path,
+                    type="MEDIA_TYPE_IMAGE",
+                )
+            ]
         )
+    elif operation == "delete":
+        media = Media(media=[])
+    else:
+        raise ValueError(f"Unsupported operation: {operation!r} (expected 'upload' or 'delete')")
 
-        if operation == "upload":
-            media = Media(
-                media=[
-                    MediaItem(
-                        relative_path=object_path,
-                        type="MEDIA_TYPE_IMAGE"
-                    )
-                ]
-            )
-        elif operation == "delete":
-            media = Media(
-                media=[]
-            )
+    provenance = Provenance(
+        integration_name=INTEGRATION_NAME,
+        data_type=DATA_TYPE,
+        source_update_time=datetime.now(timezone.utc),
+    )
 
-        client.entities.override_entity(
+    try:
+        await client.entities.override_entity(
             entity_id=entity_id,
             field_path="media.media",
             entity=Entity(
                 entity_id=entity_id,
-                media=media
+                media=media,
             ),
-            provenance=provenance
+            provenance=provenance,
         )
-    except Exception as error:
-        logging.error(f"Exception: {error}")
+    except Exception:
+        logger.exception("Failed to override entity %s", entity_id)
+        raise


### PR DESCRIPTION
* Removed the duplicate Provenance import
* Added await to client.entities.override_entity(...) 
* Moved operation validation before the API call so an unknown operation raises ValueError instead of hitting an 
* UnboundLocalError on the unbound media variable *Replaced the hardcoded "your_integration_name" with an env-var-backed constant *Re-raises exceptions after logging so callers (app.py) can actually detect failures 
* Used logger.exception to capture the traceback, not just the message string