### PR TITLE
chore(lint): address ruff v16 linting errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ For more information about the Objects API, see the following:
 
     ```bash 
     $ export LATTICE_ENDPOINT=lattice-your_env_id.env.sandboxes.developer.anduril.com
-    $ export ENVIRONMENT_TOKEN=YOUR_LATTICE_ENVIRONMENT_TOKEN
+    $ export LATTICE_CLIENT_ID=YOUR_LATTICE_CLIENT_ID
+    $ export LATTICE_CLIENT_SECRET=YOUR_LATTICE_CLIENT_SECRET
     $ export SANDBOXES_TOKEN=YOUR_LATTICE_SANDBOXES_TOKEN
     ```
 

--- a/app.py
+++ b/app.py
@@ -1,12 +1,15 @@
-from anduril import Lattice
-
-from objects import upload_object, download_object, delete_object, list_objects
-from entities import override_entity
-import os
-import sys
+import argparse
 import asyncio
 import logging
-import argparse
+import os
+import sys
+
+from anduril import Lattice
+
+from entities import override_entity
+from objects import delete_object, download_object, list_objects, upload_object
+
+logger = logging.getLogger(__name__)
 
 
 def save_object(data, object_path):
@@ -31,9 +34,9 @@ async def main(args, client):
                     object_path = (
                         f"/api/v1/objects/{upload_response.content_identifier.path}"
                     )
-                    logging.info(f"Object path: {object_path}")
+                    logger.info(f"Object path: {object_path}")
                 else:
-                    logging.error("Failed to upload object.")
+                    logger.error("Failed to upload object.")
                     sys.exit(1)
 
                 await override_entity(operation, object_path, entity_id, client)
@@ -50,12 +53,12 @@ async def main(args, client):
                 await override_entity(operation, object_path, entity_id, client)
 
             case _:
-                logging.error("Operation not supported")
+                logger.error("Operation not supported")
 
-    except asyncio.CancelledError or KeyboardInterrupt:
-        logging.error(">>>Exiting...")
-    except Exception as error:
-        logging.error(f"Exception: {error}")
+    except (asyncio.CancelledError, KeyboardInterrupt):
+        logger.error(">>>Exiting...")
+    except Exception:
+        logger.exception("An unexpected error occurred.")
 
 
 if __name__ == "__main__":
@@ -103,7 +106,7 @@ if __name__ == "__main__":
         or not lattice_endpoint
         or not sandboxes_token
     ):
-        logging.warning("Missing environment variables.")
+        logger.warning("Missing environment variables.")
         sys.exit(1)
 
     client = Lattice(

--- a/entities.py
+++ b/entities.py
@@ -1,7 +1,8 @@
-from anduril import Media, MediaItem, Entity, Provenance
-from datetime import datetime, timezone
 import logging
 import os
+from datetime import datetime, timezone
+
+from anduril import Entity, Media, MediaItem, Provenance
 
 INTEGRATION_NAME = os.getenv("INTEGRATION_NAME", "sample-app-thumbnail")
 DATA_TYPE = os.getenv("DATA_TYPE", "test_data")
@@ -46,7 +47,7 @@ async def override_entity(
     )
 
     try:
-        await client.entities.override_entity(
+        client.entities.override_entity(
             entity_id=entity_id,
             field_path="media.media",
             entity=Entity(

--- a/objects.py
+++ b/objects.py
@@ -1,5 +1,13 @@
+import asyncio
 import logging
 import os
+
+logger = logging.getLogger(__name__)
+
+
+def open_file_sync(client, object_path, file_path):
+    with open(f"{file_path}", "rb") as file:
+        return client.objects.upload_object(object_path=object_path, request=file)
 
 
 async def upload_object(file_path, client):
@@ -9,14 +17,9 @@ async def upload_object(file_path, client):
         # Define a unique path for the object using the file name.
         object_path = f"{file_name}"
         # Open the file in binary mode.
-        with open(f"{file_path}", "rb") as file:
-            print(file)
-            response = client.objects.upload_object(
-                object_path=object_path, request=file
-            )
-        return response
-    except Exception as error:
-        logging.error(f"Exception: {error}")
+        return await asyncio.to_thread(open_file_sync, client, object_path, file_path)
+    except Exception:
+        logger.exception("An unexpected error occurred.")
 
 
 async def download_object(object_path, client):
@@ -24,16 +27,16 @@ async def download_object(object_path, client):
         response = client.objects.get_object(object_path=object_path)
         chunks = [chunk for chunk in response]
         return b"".join(chunks)
-    except Exception as error:
-        logging.error(f"Exception: {error}")
+    except Exception:
+        logger.exception("An unexpected error occurred.")
 
 
 async def delete_object(object_path, client):
     try:
         response = client.objects.delete_object(object_path=object_path)
         return response
-    except Exception as error:
-        logging.error(f"Exception: {error}")
+    except Exception:
+        logger.exception("An unexpected error occurred.")
 
 
 async def list_objects(prefix, client):
@@ -42,5 +45,5 @@ async def list_objects(prefix, client):
         for item in response:
             yield item
 
-    except Exception as error:
-        logging.error(f"Exception: {error}")
+    except Exception:
+        logger.exception("An unexpected error occurred.")


### PR DESCRIPTION
### Fixes
- Incorrect README instructions for auth setup
  - `ENVIRONMENT_TOKEN` not checked by app but client creds are
app.py:
```
    lattice_endpoint = os.getenv("LATTICE_ENDPOINT")
    client_id = os.getenv("LATTICE_CLIENT_ID")
    client_secret = os.getenv("LATTICE_CLIENT_SECRET")
    # Remove sandboxes_token from the following statements if you are not developing on Sandboxes.
    sandboxes_token = os.getenv("SANDBOXES_TOKEN")
```
- incorrect await when overriding

### Lint errors addressed
- Import ordering
- Bare Exception errors
- Logging vs Logger errors